### PR TITLE
fixing link redirection and navbar

### DIFF
--- a/routes/hardware/index.js
+++ b/routes/hardware/index.js
@@ -14,7 +14,11 @@ module.exports = async function (fastify, opts) {
   });
 
   fastify.get('/:id', async function (request, reply) {
-    return reply.status(200).view('hardware.pug', {...await getHardwareData(request.params.id), title: "Hardware Details"});
+    const locals = { 
+      ...await getHardwareData(request.params.id), 
+      title: "Hardware Details" 
+    };
+    return reply.status(200).view('hardware.pug', locals);
   });
 
 

--- a/routes/inventory/index.js
+++ b/routes/inventory/index.js
@@ -6,19 +6,29 @@ const getAttendeeInventoryData = require('../../utils/attendee-inventory-data.js
 module.exports = async function (fastify, opts) {
   fastify.get('/', async function (request, reply) {
 
-    return reply.redirect('/inventory/organizer-inventory');
+    return reply.redirect('/inventory/organizer');
   });
 
   fastify.get('/organizer', async function (request, reply) {
     const { page, limit, search, categories, statuses } = request.query;
 
-    return reply.view('organizer-inventory.pug', {...await getOrganizerInventoryData({ page, limit, search, categories, statuses})});
+    const locals = {
+        ...await getOrganizerInventoryData({ page, limit, search, categories, statuses}),
+        title: "Hardware Inventory"
+    }
+
+    return reply.view('organizer-inventory.pug', locals);
   });
 
   fastify.get('/attendee', async function (request, reply) {
     const { page, limit, search, categories, statuses } = request.query;
 
-    return reply.view('attendee-inventory.pug', {...await getAttendeeInventoryData({ page, limit, search, categories, statuses})});
+    const locals = {
+        ...await getAttendeeInventoryData({ page, limit, search, categories, statuses}),
+        title: "Hardware Inventory"
+    }
+
+    return reply.view('attendee-inventory.pug', locals);
   });
 
 }

--- a/routes/inventory/index.js
+++ b/routes/inventory/index.js
@@ -6,7 +6,7 @@ const getAttendeeInventoryData = require('../../utils/attendee-inventory-data.js
 module.exports = async function (fastify, opts) {
   fastify.get('/', async function (request, reply) {
 
-    return reply.redirect('/inventory/organizer');
+    return reply.redirect('/inventory/attendee');
   });
 
   fastify.get('/organizer', async function (request, reply) {

--- a/utils/hardware-data.js
+++ b/utils/hardware-data.js
@@ -1,3 +1,5 @@
+const { fetch } = require('undici')
+
 async function getData(hardwareId) {
     const hardware = await fetch(process.env.HARDWARE_MANAGEMENT_URL + 'hardware/' + hardwareId, {
         method: 'GET',

--- a/views/includes/navbar.pug
+++ b/views/includes/navbar.pug
@@ -32,17 +32,17 @@ html
           img.mb-1(src="/public/images/logo-primary.png", alt="Logo")
           span.mx-1
           | YCP Hacks
-          button.navbar-toggler(type="button", data-bs-toggle="collapse", data-bs-target="#navbarNav", aria-controls="navbarNav", aria-expanded="false", aria-label="Toggle navigation")
-            span.navbar-toggler-icon
-          #navbarNav.collapse.navbar-collapse
-            ul.navbar-nav
-              li.nav-item
-                a.nav-link.disabled(href="#") Dashboard
-              li.nav-item
-                a.nav-link.active(href="/") Hardware Checkout
-              li.nav-item
-                a.nav-link(href="#") Event Control Panel
-              li.nav-item
-                a.nav-link.disabled(href="#") Team Management
-              li.nav-item
-                a.nav-link.disabled(href="#") Profile
+        button.navbar-toggler(type="button", data-bs-toggle="collapse", data-bs-target="#navbarNav", aria-controls="navbarNav", aria-expanded="false", aria-label="Toggle navigation")
+          span.navbar-toggler-icon
+        #navbarNav.collapse.navbar-collapse
+          ul.navbar-nav
+            li.nav-item
+              a.nav-link.disabled(href="#") Dashboard
+            li.nav-item
+              a.nav-link.active(href="/inventory") Hardware Checkout
+            li.nav-item
+              a.nav-link(href="#") Event Control Panel
+            li.nav-item
+              a.nav-link.disabled(href="#") Team Management
+            li.nav-item
+              a.nav-link.disabled(href="#") Profile


### PR DESCRIPTION
This PR makes it so the Navbar styling is fixed. The Navbar link for the Hardware Checkout also works. Right now all it does is send you to the basic "/inventory" page where that route will redirect you to the "/inventory/attendee" route by default. Later, the "/inventory" route will redirect you based on the role of the user; i.e. "/inventory/organizer" if role == organizer and "/inventory/attendee" if role == attendee.